### PR TITLE
fixed loop flickering probably i think

### DIFF
--- a/src/systems/world_loop/loop_manager.gd
+++ b/src/systems/world_loop/loop_manager.gd
@@ -43,7 +43,7 @@ func _ready() -> void:
 
 	shape_detect = Utils.get_child_node_or_null(loop_objects_detect, "detect_shape")
 	
-func _process(_detla: float) -> void:
+func _physics_process(delta: float) -> void:
 	if Engine.is_editor_hint(): (shape_detect.shape as RectangleShape2D).size = world_size
 	else: 						update_dupe_nodes.emit()
 		


### PR DESCRIPTION
todo would be to spawn position and move footstep dust as relative to Madotsuki rather than the world, so that the particles don't "snap" across the warp boundary